### PR TITLE
Fix wrong position of messageView for modal UITableViewController

### DIFF
--- a/GSMessages/GSMessage.swift
+++ b/GSMessages/GSMessage.swift
@@ -158,8 +158,6 @@ public class GSMessage {
     fileprivate var messageHeight: CGFloat { return offsetY + height }
 
     init(text: String, type: GSMessageType, options: [GSMessageOption]?, inView: UIView, inViewController: UIViewController?) {
-
-        var inView = inView
         
         switch type {
         case .success:  backgroundColor = GSMessage.successBackgroundColor
@@ -183,12 +181,6 @@ public class GSMessage {
                 case let .textAlignment(value): textAlignment = value
                 case let .textNumberOfLines(value): textNumberOfLines = value
                 }
-            }
-        }
-
-        if inViewController is UITableViewController {
-            if let lastWindow = UIApplication.shared.windows.last {
-                inView = lastWindow as UIView
             }
         }
 


### PR DESCRIPTION
For some reason, code from https://github.com/wxxsw/GSMessages/commit/fbcc49f785d577d0e34ec93d70ad779f7d71bbb0 breaks initial position for messageView. 
![simulator screen shot 17 2017 10 58 54](https://cloud.githubusercontent.com/assets/420242/24024649/d3dfd906-0b00-11e7-8020-418d656e0ead.png)